### PR TITLE
Update navbar.mustache

### DIFF
--- a/Assets/WebsiteAssets/templates/partials/navbar.mustache
+++ b/Assets/WebsiteAssets/templates/partials/navbar.mustache
@@ -12,7 +12,8 @@
 				</a>
 			</div>
 			<div class="col-9 text-right d-none d-md-block">
-				{{> twitterLink}}
+				<a href="https://twitter.com/joplinapp" title="Joplin Twitter feed" class="fw500"><i class="fab fa-twitter"></i></a>
+				<a href="https://github.com/laurent22/joplin/" title="Joplin GitHub repository" class="fw500"><i class="fab fa-github"></i></a>
 				<a href="{{baseUrl}}/news/" class="fw500">News</a>
 				<a href="{{baseUrl}}/help/" class="fw500">Help</a>
 				<a href="{{forumUrl}}" class="fw500">Forum</a>


### PR DESCRIPTION
This PR is an additional feature update which is an hyperlink that redirect the user to Joplin's official GitHub repository. As Joplin is an open-source organization people tend to check out the official GitHub repo, so I provided it in the main navbar which created an easy pathway to the GitHub for the user. 
Hope you like it.

Before:
<img width="1232" alt="Screenshot 2022-04-13 at 9 59 13 PM" src="https://user-images.githubusercontent.com/80835071/163227240-17c4dad4-7186-42c0-abfa-468beed86741.png">

After:
<img width="1232" alt="Screenshot 2022-04-13 at 9 59 07 PM" src="https://user-images.githubusercontent.com/80835071/163227388-6a39d9d0-7920-47c3-bdad-5e340e9a4545.png">

Thank You. 